### PR TITLE
Added option for modifying JWT header

### DIFF
--- a/src/sd_jwt/bin/generate.py
+++ b/src/sd_jwt/bin/generate.py
@@ -39,6 +39,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     use_decoys = testcase.get("add_decoy_claims", False)
     serialization_format = testcase.get("serialization_format", "compact")
     include_default_claims = testcase.get("include_default_claims", True)
+    extra_header_parameters = testcase.get("extra_header_parameters", None)
 
     claims = {}
     if include_default_claims:
@@ -58,6 +59,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
         demo_keys["holder_key"] if testcase.get("key_binding", False) else None,
         add_decoy_claims=use_decoys,
         serialization_format=serialization_format,
+        extra_header_parameters=extra_header_parameters,
     )
 
     ### Produce SD-JWT-R for selected example
@@ -81,7 +83,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
 
     # Define a function to check the issuer and retrieve the
     # matching public key
-    def cb_get_issuer_key(issuer):
+    def cb_get_issuer_key(issuer, header_parameters):
         # Do not use in production - this allows to use any issuer name for demo purposes
         if issuer == claims.get("iss", None):
             return demo_keys["issuer_public_key"]

--- a/src/sd_jwt/common.py
+++ b/src/sd_jwt/common.py
@@ -9,7 +9,6 @@ from typing import List
 DEFAULT_SIGNING_ALG = "ES256"
 SD_DIGESTS_KEY = "_sd"
 DIGEST_ALG_KEY = "_sd_alg"
-KB_DIGEST_KEY = "_sd_hash"
 SD_LIST_PREFIX = "..."
 
 
@@ -40,7 +39,7 @@ class SDJWTCommon:
     JWS_KEY_KB_JWT = "kb_jwt"
     HASH_ALG = {"name": "sha-256", "fn": sha256}
 
-    COMBINED_SERIALIZATION_FORMAT_SEPARATOR = "~"
+    COMBINED_serialization_FORMAT_SEPARATOR = "~"
 
     unsafe_randomness = False
 
@@ -54,10 +53,10 @@ class SDJWTCommon:
         return self._base64url_encode(self.HASH_ALG["fn"](raw).digest())
 
     def _combine(self, *parts):
-        return self.COMBINED_SERIALIZATION_FORMAT_SEPARATOR.join(parts)
+        return self.COMBINED_serialization_FORMAT_SEPARATOR.join(parts)
 
     def _split(self, combined):
-        return combined.split(self.COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
+        return combined.split(self.COMBINED_serialization_FORMAT_SEPARATOR)
 
     @staticmethod
     def _base64url_encode(data: bytes) -> str:

--- a/src/sd_jwt/common.py
+++ b/src/sd_jwt/common.py
@@ -33,7 +33,7 @@ class SDJWTHasSDClaimException(Exception):
 
 
 class SDJWTCommon:
-    SD_JWT_HEADER = None  # "sd+jwt"
+    SD_JWT_TYP_HEADER = None  # "sd+jwt"
     KB_JWT_TYP_HEADER = "kb+jwt"
     JWS_KEY_DISCLOSURES = "disclosures"
     JWS_KEY_KB_JWT = "kb_jwt"

--- a/src/sd_jwt/common.py
+++ b/src/sd_jwt/common.py
@@ -9,6 +9,7 @@ from typing import List
 DEFAULT_SIGNING_ALG = "ES256"
 SD_DIGESTS_KEY = "_sd"
 DIGEST_ALG_KEY = "_sd_alg"
+KB_DIGEST_KEY = "_sd_hash"
 SD_LIST_PREFIX = "..."
 
 
@@ -39,7 +40,7 @@ class SDJWTCommon:
     JWS_KEY_KB_JWT = "kb_jwt"
     HASH_ALG = {"name": "sha-256", "fn": sha256}
 
-    COMBINED_serialization_FORMAT_SEPARATOR = "~"
+    COMBINED_SERIALIZATION_FORMAT_SEPARATOR = "~"
 
     unsafe_randomness = False
 
@@ -53,10 +54,10 @@ class SDJWTCommon:
         return self._base64url_encode(self.HASH_ALG["fn"](raw).digest())
 
     def _combine(self, *parts):
-        return self.COMBINED_serialization_FORMAT_SEPARATOR.join(parts)
+        return self.COMBINED_SERIALIZATION_FORMAT_SEPARATOR.join(parts)
 
     def _split(self, combined):
-        return combined.split(self.COMBINED_serialization_FORMAT_SEPARATOR)
+        return combined.split(self.COMBINED_SERIALIZATION_FORMAT_SEPARATOR)
 
     @staticmethod
     def _base64url_encode(data: bytes) -> str:

--- a/src/sd_jwt/holder.py
+++ b/src/sd_jwt/holder.py
@@ -1,4 +1,4 @@
-from .common import SDJWTCommon, DEFAULT_SIGNING_ALG, SD_DIGESTS_KEY, SD_LIST_PREFIX, KB_DIGEST_KEY
+from .common import SDJWTCommon, DEFAULT_SIGNING_ALG, SD_DIGESTS_KEY, SD_LIST_PREFIX
 from json import dumps, loads
 from time import time
 from typing import Dict, List, Optional
@@ -42,17 +42,10 @@ class SDJWTHolder(SDJWTCommon):
 
         # Optional: Create a key binding JWT
         if nonce and aud and holder_key:
-            # Temporarily create the combined presentation in order to create the hash over it
-            string_to_hash = self._combine(
-                    self.serialized_sd_jwt,
-                    *self.hs_disclosures,
-                    ""
-                )
-            sd_jwt_presentation_hash = self._b64hash(string_to_hash.encode("ascii"))
-            self._create_key_binding_jwt(nonce, aud, sd_jwt_presentation_hash, holder_key, sign_alg)
-
+            self._create_key_binding_jwt(nonce, aud, holder_key, sign_alg)
 
         # Create the combined presentation
+
         if self._serialization_format == "compact":
             # Note: If the key binding JWT is not created, then the
             # last element is empty, matching the spec.
@@ -201,7 +194,7 @@ class SDJWTHolder(SDJWTCommon):
                 self._select_disclosures(value, claims_to_disclose.get(key, None))
 
     def _create_key_binding_jwt(
-        self, nonce, aud, presentation_hash, holder_key, sign_alg: Optional[str] = None
+        self, nonce, aud, holder_key, sign_alg: Optional[str] = None
     ):
         _alg = sign_alg or DEFAULT_SIGNING_ALG
 
@@ -214,7 +207,6 @@ class SDJWTHolder(SDJWTCommon):
             "nonce": nonce,
             "aud": aud,
             "iat": int(time()),
-            KB_DIGEST_KEY: presentation_hash,
         }
 
         # Sign the SD-JWT-Release using the holder's key

--- a/src/sd_jwt/holder.py
+++ b/src/sd_jwt/holder.py
@@ -1,4 +1,4 @@
-from .common import SDJWTCommon, DEFAULT_SIGNING_ALG, SD_DIGESTS_KEY, SD_LIST_PREFIX
+from .common import SDJWTCommon, DEFAULT_SIGNING_ALG, SD_DIGESTS_KEY, SD_LIST_PREFIX, KB_DIGEST_KEY
 from json import dumps, loads
 from time import time
 from typing import Dict, List, Optional
@@ -42,10 +42,17 @@ class SDJWTHolder(SDJWTCommon):
 
         # Optional: Create a key binding JWT
         if nonce and aud and holder_key:
-            self._create_key_binding_jwt(nonce, aud, holder_key, sign_alg)
+            # Temporarily create the combined presentation in order to create the hash over it
+            string_to_hash = self._combine(
+                    self.serialized_sd_jwt,
+                    *self.hs_disclosures,
+                    ""
+                )
+            sd_jwt_presentation_hash = self._b64hash(string_to_hash.encode("ascii"))
+            self._create_key_binding_jwt(nonce, aud, sd_jwt_presentation_hash, holder_key, sign_alg)
+
 
         # Create the combined presentation
-
         if self._serialization_format == "compact":
             # Note: If the key binding JWT is not created, then the
             # last element is empty, matching the spec.
@@ -194,7 +201,7 @@ class SDJWTHolder(SDJWTCommon):
                 self._select_disclosures(value, claims_to_disclose.get(key, None))
 
     def _create_key_binding_jwt(
-        self, nonce, aud, holder_key, sign_alg: Optional[str] = None
+        self, nonce, aud, presentation_hash, holder_key, sign_alg: Optional[str] = None
     ):
         _alg = sign_alg or DEFAULT_SIGNING_ALG
 
@@ -207,6 +214,7 @@ class SDJWTHolder(SDJWTCommon):
             "nonce": nonce,
             "aud": aud,
             "iat": int(time()),
+            KB_DIGEST_KEY: presentation_hash,
         }
 
         # Sign the SD-JWT-Release using the holder's key

--- a/src/sd_jwt/issuer.py
+++ b/src/sd_jwt/issuer.py
@@ -198,6 +198,6 @@ class SDJWTIssuer(SDJWTCommon):
             self.sd_jwt_issuance = self._combine(
                 self.serialized_sd_jwt, *(d.b64 for d in self.ii_disclosures)
             )
-            self.sd_jwt_issuance += self.COMBINED_serialization_FORMAT_SEPARATOR
+            self.sd_jwt_issuance += self.COMBINED_SERIALIZATION_FORMAT_SEPARATOR
         else:
             self.sd_jwt_issuance = self.serialized_sd_jwt

--- a/src/sd_jwt/issuer.py
+++ b/src/sd_jwt/issuer.py
@@ -36,6 +36,7 @@ class SDJWTIssuer(SDJWTCommon):
         sign_alg=None,
         add_decoy_claims: bool = False,
         serialization_format: str = "compact",
+        extra_header_parameters: Dict = None,
     ):
         super().__init__(serialization_format=serialization_format)
 
@@ -44,6 +45,7 @@ class SDJWTIssuer(SDJWTCommon):
         self._holder_key = holder_key
         self._sign_alg = sign_alg or DEFAULT_SIGNING_ALG
         self._add_decoy_claims = add_decoy_claims
+        self._extra_header_parameters = extra_header_parameters
 
         self.ii_disclosures = []
         self.decoy_digests = []
@@ -168,8 +170,10 @@ class SDJWTIssuer(SDJWTCommon):
 
         # Assemble protected headers
         _protected_headers = {"alg": self._sign_alg}
-        if self.SD_JWT_HEADER:
-            _protected_headers["typ"] = self.SD_JWT_HEADER
+        if self.SD_JWT_TYP_HEADER:
+            _protected_headers["typ"] = self.SD_JWT_TYP_HEADER
+        if self._extra_header_parameters:
+            _protected_headers.update(self._extra_header_parameters)
 
         self.sd_jwt.add_signature(
             self._issuer_key,

--- a/src/sd_jwt/issuer.py
+++ b/src/sd_jwt/issuer.py
@@ -198,6 +198,6 @@ class SDJWTIssuer(SDJWTCommon):
             self.sd_jwt_issuance = self._combine(
                 self.serialized_sd_jwt, *(d.b64 for d in self.ii_disclosures)
             )
-            self.sd_jwt_issuance += self.COMBINED_SERIALIZATION_FORMAT_SEPARATOR
+            self.sd_jwt_issuance += self.COMBINED_serialization_FORMAT_SEPARATOR
         else:
             self.sd_jwt_issuance = self.serialized_sd_jwt

--- a/src/sd_jwt/verifier.py
+++ b/src/sd_jwt/verifier.py
@@ -21,7 +21,7 @@ class SDJWTVerifier(SDJWTCommon):
     def __init__(
         self,
         sd_jwt_presentation: str,
-        cb_get_issuer_key: Callable[[str], str],
+        cb_get_issuer_key: Callable[[str, Dict], str],
         expected_aud: Union[str, None] = None,
         expected_nonce: Union[str, None] = None,
         serialization_format: str = "compact",
@@ -57,7 +57,8 @@ class SDJWTVerifier(SDJWTCommon):
         parsed_input_sd_jwt.deserialize(self._unverified_input_sd_jwt)
 
         unverified_issuer = self._unverified_input_sd_jwt_payload.get("iss", None)
-        issuer_public_key = cb_get_issuer_key(unverified_issuer)
+        unverified_header_parameters = parsed_input_sd_jwt.jose_header
+        issuer_public_key = cb_get_issuer_key(unverified_issuer, unverified_header_parameters)
         parsed_input_sd_jwt.verify(issuer_public_key, alg=sign_alg)
 
         self._sd_jwt_payload = loads(parsed_input_sd_jwt.payload.decode("utf-8"))

--- a/src/sd_jwt/verifier.py
+++ b/src/sd_jwt/verifier.py
@@ -4,6 +4,7 @@ from .common import (
     DIGEST_ALG_KEY,
     SD_DIGESTS_KEY,
     SD_LIST_PREFIX,
+    KB_DIGEST_KEY,
 )
 
 from json import dumps, loads
@@ -72,10 +73,13 @@ class SDJWTVerifier(SDJWTCommon):
         expected_nonce: Union[str, None] = None,
         sign_alg: Union[str, None] = None,
     ):
+
+        # Deserialized the key binding JWT
         _alg = sign_alg or DEFAULT_SIGNING_ALG
         parsed_input_key_binding_jwt = JWS()
         parsed_input_key_binding_jwt.deserialize(self._unverified_input_key_binding_jwt)
 
+        # Verify the key binding JWT using the holder public key
         if not self._holder_public_key_payload:
             raise ValueError("No holder public key in SD-JWT")
 
@@ -91,17 +95,31 @@ class SDJWTVerifier(SDJWTCommon):
 
         parsed_input_key_binding_jwt.verify(pubkey, alg=_alg)
 
+        # Check header typ
         key_binding_jwt_header = parsed_input_key_binding_jwt.jose_header
 
         if key_binding_jwt_header["typ"] != self.KB_JWT_TYP_HEADER:
             raise ValueError("Invalid header typ")
 
+        # Check payload
         key_binding_jwt_payload = loads(parsed_input_key_binding_jwt.payload)
 
         if key_binding_jwt_payload["aud"] != expected_aud:
-            raise ValueError("Invalid audience")
+            raise ValueError("Invalid audience in KB-JWT")
         if key_binding_jwt_payload["nonce"] != expected_nonce:
-            raise ValueError("Invalid nonce")
+            raise ValueError("Invalid nonce in KB-JWT")
+
+        # Reassemble the SD-JWT in compact format and check digest
+        if self._serialization_format == "compact":
+            string_to_hash = self._combine(
+                        self._unverified_input_sd_jwt,
+                        *self._input_disclosures,
+                        ""
+            )
+            expected_sd_jwt_presentation_hash = self._b64hash(string_to_hash.encode("ascii"))
+
+            if key_binding_jwt_payload[KB_DIGEST_KEY] != expected_sd_jwt_presentation_hash:
+                raise ValueError("Invalid digest in KB-JWT")
 
     def _extract_sd_claims(self):
         if DIGEST_ALG_KEY in self._sd_jwt_payload:

--- a/tests/testcases/header_mod/specification.yml
+++ b/tests/testcases/header_mod/specification.yml
@@ -1,0 +1,33 @@
+user_claims:
+  !sd sub: john_doe_42
+  !sd given_name: John
+  !sd family_name: Doe
+  !sd email: johndoe@example.com
+  !sd phone_number: +1-202-555-0101
+  !sd address:
+    street_address: 123 Main St
+    locality: Anytown
+    region: Anystate
+    country: US
+  !sd birthdate: "1940-01-01"
+
+holder_disclosed_claims:
+  given_name: true
+  family_name: true
+  address: true
+
+extra_header_parameters:
+  kid: 42
+
+expect_verified_user_claims:
+  given_name: John
+  family_name: Doe
+  address: 
+    street_address: 123 Main St
+    locality: Anytown
+    region: Anystate
+    country: US
+
+key_binding: True
+
+serialization_format: compact


### PR DESCRIPTION
This allows for inclusion of extra header parameters like `kid` using the YAML key `extra_header_parameters` (a dict). See https://github.com/vcstuff/oauth-sd-jwt-vc/issues/99